### PR TITLE
ResourceGUID refactor

### DIFF
--- a/Poly/src/Poly/Rendering/RenderGraph/Pass.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/Pass.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ResourceGUID.h"
 #include "PassReflection.h"
 #include "RenderGraphTypes.h"
 
@@ -21,6 +22,12 @@ namespace Poly
 			RENDER,
 			COMPUTE,
 			SYNC
+		};
+
+		struct ExternalResourceData
+		{
+			ResourceGUID SrcGUID;
+			ResourceGUID DstGUID;
 		};
 
 	public:
@@ -61,7 +68,7 @@ namespace Poly
 		/**
 		 * @return read-only vector of external resources
 		 */
-		const std::vector<std::pair<std::string, std::string>>& GetExternalResources() const { return p_ExternalResources; }
+		const std::vector<ExternalResourceData>& GetExternalResources() const { return p_ExternalResources; }
 
 		/**
 		 * @return type of pass
@@ -130,7 +137,7 @@ namespace Poly
 		std::vector<uint32> p_AutoBindedSets;
 
 		// Pair structure: first: External resource name (src), second: Render pass input name (dst)
-		std::vector<std::pair<std::string, std::string>> p_ExternalResources;
+		std::vector<ExternalResourceData> p_ExternalResources;
 
 		// Variables for custom usage of passes
 		Ref<PipelineDesc> p_pPipelineDesc = nullptr;

--- a/Poly/src/Poly/Rendering/RenderGraph/PassReflection.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/PassReflection.cpp
@@ -180,7 +180,6 @@ namespace Poly
 
 	const IOData& PassReflection::GetIOData(const std::string& resName) const
 	{
-		//auto it = std::find(m_IOs.begin(), m_IOs.end(), resName);
 		auto it = std::find_if(m_IOs.begin(), m_IOs.end(), [resName](const IOData& io) { return io.Name == resName; });
 		if (it != m_IOs.end())
 			return *it;

--- a/Poly/src/Poly/Rendering/RenderGraph/Passes/ImGuiPass.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/Passes/ImGuiPass.cpp
@@ -70,7 +70,7 @@ namespace Poly
 		{
 			Ref<Resource> pRes = Resource::Create(m_pFontTexture, m_pFontTextureView, "FontTexture");
 			pRes->SetSampler(m_pFontSampler);
-			context.GetRenderGraphProgram()->UpdateGraphResource("ImGuiPass.FontTexture", pRes.get());
+			context.GetRenderGraphProgram()->UpdateGraphResource({ "ImGuiPass.FontTexture" }, pRes.get());
 			first = false;
 		}
 		// TODO: Should probably not call Render() here

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderData.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderData.cpp
@@ -20,11 +20,13 @@ namespace Poly
 
 	Resource* RenderData::GetResourceNonConst(const std::string& resourceName) const
 	{
-		return m_pResourceCache->GetResource(m_RenderPassName + "." + resourceName);
+		// ResourceGUID is created within the function to avoid the pass to get resources outside of pass scope
+		return m_pResourceCache->GetResource({ m_RenderPassName, resourceName });
 	}
 
 	const Resource* RenderData::operator[] (const std::string& resourceName) const
 	{
-		return m_pResourceCache->GetResource(m_RenderPassName + "." + resourceName);
+		// ResourceGUID is created within the function to avoid the pass to get resources outside of pass scope
+		return m_pResourceCache->GetResource({ m_RenderPassName, resourceName });
 	}
 }

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraph.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraph.cpp
@@ -95,7 +95,8 @@ namespace Poly
 			}
 
 			uint32 nodeIndex = m_NameToNodeIndex[dst.GetPassName()];
-			m_Passes[nodeIndex]->p_ExternalResources.push_back({ src.GetResourceName(), dst.GetResourceName()});
+			Pass::ExternalResourceData data = { .SrcGUID = src, .DstGUID = dst };
+			m_Passes[nodeIndex]->p_ExternalResources.emplace_back(std::move(data));
 
 			return true;
 		}

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraph.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraph.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RenderGraphTypes.h"
+#include "ResourceGUID.h"
 
 #include <unordered_set>
 
@@ -26,8 +27,8 @@ namespace Poly
 		struct EdgeData
 		{
 			// If auto generation is added - mark it here
-			std::string Src;
-			std::string Dst;
+			ResourceGUID Src = ResourceGUID::Invalid();
+			ResourceGUID Dst = ResourceGUID::Invalid();
 		};
 
 	public:
@@ -78,7 +79,7 @@ namespace Poly
 		 * @param dst - dst pass/resource name
 		 * @return true if link is added successfully
 		 */
-		bool AddLink(const std::string& src, const std::string& dst);
+		bool AddLink(const ResourceGUID& src, const ResourceGUID& dst);
 
 		/**
 		 * Remove an already existing link, must follow same structure of names as AddLink
@@ -86,7 +87,7 @@ namespace Poly
 		 * @param dst - dst pass/resource name
 		 * @return true if link is removed successfully
 		 */
-		bool RemoveLink(const std::string& src, const std::string& dst);
+		bool RemoveLink(const ResourceGUID& src, const ResourceGUID& dst);
 
 		/**
 		 * Add a global input resource node to the graph. This resource will be in the global space
@@ -111,21 +112,21 @@ namespace Poly
 		/**
 		 * Add a global input resource node to the graph. This resource will be in the global space
 		 * which means it will use the $ prefix, i.e. resource name will become $.resource
-		 * @param name - Resource name without any prefix - prefix is automatically added
+		 * @param resourceGUID - Resource GUID. External resources use "$" or "" for pass name
 		 * @param size - Size of the buffer that will be used for this resource
 		 * @param bufferUsage - Type of buffer
 		 * @param data - (Optional) pointer to data if transfer to buffer should be done at creation of buffer
 		 * @param autoBindDescriptor - Decides if the render graph should automatically bind descriptors. Defaulted to true
 		 * @return true if resource could be added sucessfully and potentially have data transfered to it
 		 */
-		bool AddExternalResource(const std::string& name, uint64 size, FBufferUsage bufferUsage, const void* data = nullptr, bool autoBindDescriptor = true);
+		bool AddExternalResource(const ResourceGUID& resourceGUID, uint64 size, FBufferUsage bufferUsage, const void* data = nullptr, bool autoBindDescriptor = true);
 
 		/**
 		 * Removes a previously added external resource
 		 * @param name - Name of resource to remove
 		 * @return true if resource could be removed successfully
 		 */
-		bool RemoveExternalResource(const std::string& name);
+		bool RemoveExternalResource(const ResourceGUID& resourceGUID);
 
 		/**
 		 * Marks the given RenderPass name to be an output of the graph
@@ -133,14 +134,14 @@ namespace Poly
 		 * @param name	- Resource to mark following renderPass.resource structure
 		 * @return true if output could be added successfully
 		 */
-		bool MarkOutput(const std::string& name);
+		bool MarkOutput(const ResourceGUID& resourceGUID);
 
 		/**
 		 * Unmarks the given RenderPass name to no longer be an output of the graph
 		 * @param name	- Resource to unmark following renderPass.resource structure
 		 * @return true if output could be added successfully
 		 */
-		bool UnmarkOutput(const std::string& name);
+		bool UnmarkOutput(const ResourceGUID& resourceGUID);
 
 		/**
 		 * @return EdgeData for specified edgeID
@@ -187,18 +188,13 @@ namespace Poly
 			}
 		};
 
-		/**
-		 * @return pair.first = Render pass name, pair.second = resource name belonging to the aforementioned pass
-		 */
-		std::pair<std::string, std::string> GetPassNameResourcePair(std::string name);
-
 		std::string m_Name = "";
 		Ref<DirectedGraph> m_pGraph;
 		std::unordered_map<std::string, uint32> m_NameToNodeIndex;
 		std::unordered_map<uint32, Ref<Pass>> m_Passes;
 		std::unordered_map<uint32, EdgeData> m_Edges;
 		std::unordered_set<Output, OutputKeyHasher> m_Outputs;
-		std::unordered_map<std::string, ResourceInfo> m_ExternalResources;
+		std::unordered_map<ResourceGUID, ResourceInfo, ResourceGUIDHasher> m_ExternalResources;
 		RenderGraphDefaultParams m_DefaultParams;
 	};
 }

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraphCompiler.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraphCompiler.cpp
@@ -51,15 +51,12 @@ namespace Poly
 			mandatoryPasses.insert(output.NodeID);
 
 		// 2. Add all passes which has an execution link, since this might affect other mandatory passes
-		for (const auto& edge : m_pRenderGraph->m_Edges)
+		for (const auto& [_, edgeData] : m_pRenderGraph->m_Edges)
 		{
-			// Remove dstPair or srcPair check? If one is true the other should also be (check done when link is added)
-			auto srcPair = m_pRenderGraph->GetPassNameResourcePair(edge.second.Src);
-			auto dstPair = m_pRenderGraph->GetPassNameResourcePair(edge.second.Dst);
-			if (srcPair.second.empty() && dstPair.second.empty())
+			if (!edgeData.Src.HasResource() && !edgeData.Dst.HasResource())
 			{
-				mandatoryPasses.insert(m_pRenderGraph->m_NameToNodeIndex[srcPair.first]);
-				mandatoryPasses.insert(m_pRenderGraph->m_NameToNodeIndex[dstPair.first]);
+				mandatoryPasses.insert(m_pRenderGraph->m_NameToNodeIndex[edgeData.Src.GetPassName()]);
+				mandatoryPasses.insert(m_pRenderGraph->m_NameToNodeIndex[edgeData.Dst.GetPassName()]);
 			}
 		}
 
@@ -156,8 +153,8 @@ namespace Poly
 		m_pResourceCache = ResourceCache::Create(m_DefaultParams);
 
 		// Register external resources
-		for (const auto& resPair : m_pRenderGraph->m_ExternalResources)
-			m_pResourceCache->RegisterExternalResource("$." + resPair.first, resPair.second);
+		for (const auto& [resGUID, resInfo] : m_pRenderGraph->m_ExternalResources)
+			m_pResourceCache->RegisterExternalResource(resGUID, resInfo);
 
 		for (uint32 passID = 0; passID < m_OrderedPasses.size(); passID++)
 		{
@@ -167,7 +164,7 @@ namespace Poly
 			const auto& outputs = passData.Reflection.GetIOData(FIOType::OUTPUT, FResourceBindPoint::ALL_SCENES);
 			for (auto& output : outputs)
 			{
-				std::string resourceName = passData.pPass->GetName() + "." + output.Name;
+				ResourceGUID resourceGUID(passData.pPass->GetName(), output.Name);
 
 				// Check if resource is being used, as the graph allows outputs to be non-linked, go to next output if not used
 				bool isMarkedOutput = IsResourceGraphOutput(passData.NodeIndex, output.Name);
@@ -181,56 +178,56 @@ namespace Poly
 
 				if (isMarkedOutput && !BitsSet(output.IOType, FIOType::INPUT)) // Create alias to backbuffer
 				{
-					m_pResourceCache->MarkOutput(passData.pPass->GetName() + "." + output.Name, output);
+					m_pResourceCache->MarkOutput(resourceGUID, output);
 					passData.Reflection.SetFormat(output.Name, EFormat::B8G8R8A8_UNORM);
 				}
 				else if (!BitsSet(output.IOType, FIOType::INPUT) && !BitsSet(output.BindPoint, FResourceBindPoint::INTERNAL_USE)) // Only register new resource if it wasn't an input (passthrough)
-					m_pResourceCache->RegisterResource(passData.pPass->GetName() + "." + output.Name, passID, output);
+					m_pResourceCache->RegisterResource(resourceGUID, passID, output);
 			}
 
 			// Make aliases of the inputs
 			const auto& inputs = passData.Reflection.GetIOData(FIOType::INPUT, FResourceBindPoint::ALL_SCENES);
 			for (auto& input : inputs)
 			{
-				std::string resourceName = passData.pPass->GetName() + "." + input.Name;
-				std::string alias = "";
+				ResourceGUID resourceGUID(passData.pPass->GetName(), input.Name);
+				ResourceGUID aliasGUID = ResourceGUID::Invalid();
 
 				const auto& incommingEdges = m_pRenderGraph->m_pGraph->GetNode(passData.NodeIndex)->GetIncommingEdges();
 				for (auto edgeID : incommingEdges)
 				{
 					auto& edgeData = m_pRenderGraph->m_Edges[edgeID];
-					if (edgeData.Dst == resourceName)
+					if (edgeData.Dst == resourceGUID)
 					{
-						alias = edgeData.Src;
+						aliasGUID = edgeData.Src;
 						break;
 					}
 				}
 
 				// If incomming didn't get any match, check for externals
-				if (alias.empty())
+				if (!aliasGUID.HasResource())
 				{
 					const auto& externals = passData.pPass->GetExternalResources();
 					for (auto& external : externals)
 					{
 						if (external.second == input.Name)
 						{
-							alias = "$." + external.first;
+							aliasGUID = ResourceGUID(external.first);
 							break;
 						}
 					}
 				}
 
-				if (alias.empty() && !BitsSet(input.BindPoint, FResourceBindPoint::INTERNAL_USE))
+				if (!aliasGUID.HasResource() && !BitsSet(input.BindPoint, FResourceBindPoint::INTERNAL_USE))
 				{
-					POLY_CORE_ERROR("No resource linkage was found for {}, this should now happen and should have been found earlier", resourceName);
+					POLY_CORE_ERROR("No resource linkage was found for {}, this should now happen and should have been found earlier", resourceGUID.GetFullName());
 					return;
 				}
 
-				m_pResourceCache->RegisterResource(passData.pPass->GetName() + "." + input.Name, passID, input, alias);
+				m_pResourceCache->RegisterResource(resourceGUID, passID, input, aliasGUID);
 
 				if (IsResourceGraphOutput(passData.NodeIndex, input.Name))
 				{
-					m_pResourceCache->MarkOutput(passData.pPass->GetName() + "." + input.Name, input);
+					m_pResourceCache->MarkOutput(resourceGUID, input);
 					passData.Reflection.SetFormat(input.Name, EFormat::B8G8R8A8_UNORM);
 				}
 			}
@@ -355,14 +352,12 @@ namespace Poly
 			for (const auto& edgeID : incommingEdges)
 			{
 				// If external, check if we are reading or writing. If writing and texture, use layout undefined
-				const std::string& srcName = m_pRenderGraph->m_Edges[edgeID].Src;
-				const std::string& dstName = m_pRenderGraph->m_Edges[edgeID].Dst;
-				PassResourcePair srcPair = m_pRenderGraph->GetPassNameResourcePair(srcName);
-				PassResourcePair dstPair = m_pRenderGraph->GetPassNameResourcePair(dstName);
-				if (srcPair.first == "$") // External
+				const ResourceGUID srcGUID = m_pRenderGraph->m_Edges[edgeID].Src;
+				const ResourceGUID dstGUID = m_pRenderGraph->m_Edges[edgeID].Dst;
+				if (srcGUID.IsExternal()) // External
 				{
 					auto& barriers = m_Invalidates[passData.NodeIndex];
-					auto itr = std::find_if(barriers.begin(), barriers.end(), [&](const HalfBarrier& b){ return b.Name == dstPair.second; });
+					auto itr = std::find_if(barriers.begin(), barriers.end(), [&dstGUID](const HalfBarrier& b){ return b.Name == dstGUID.GetResourceName(); });
 
 					// Check if it is a texture or a buffer
 					if (itr->TextureLayout != ETextureLayout::UNDEFINED) // Texture
@@ -393,10 +388,10 @@ namespace Poly
 				}
 				else // From another pass
 				{
-					auto& flushBarriers = m_Flushes[m_pRenderGraph->m_NameToNodeIndex[srcPair.first]];
-					auto srcItr = std::find_if(flushBarriers.begin(), flushBarriers.end(), [&](const HalfBarrier& b){ return b.Name == srcPair.second; });
+					auto& flushBarriers = m_Flushes[m_pRenderGraph->m_NameToNodeIndex[srcGUID.GetPassName()]];
+					auto srcItr = std::find_if(flushBarriers.begin(), flushBarriers.end(), [&srcGUID](const HalfBarrier& b){ return b.Name == srcGUID.GetResourceName(); });
 					auto& invalidateBarriers = m_Invalidates[passData.NodeIndex];
-					auto dstItr = std::find_if(invalidateBarriers.begin(), invalidateBarriers.end(), [&](const HalfBarrier& b){ return b.Name == dstPair.second; });
+					auto dstItr = std::find_if(invalidateBarriers.begin(), invalidateBarriers.end(), [&dstGUID](const HalfBarrier& b){ return b.Name == dstGUID.GetResourceName(); });
 
 					if (dstItr->TextureLayout != ETextureLayout::UNDEFINED) // Texture
 					{
@@ -406,11 +401,11 @@ namespace Poly
 						{
 							// Write after read - execution barrier needed - for simplicity a normal barrier is added
 							if (!syncPass)
-								syncPass = SyncPass::Create("Presync for " + dstPair.first);
+								syncPass = SyncPass::Create("Presync for " + dstGUID.GetPassName());
 
 							SyncPass::SyncData data = {};
 							data.Type				= SyncPass::SyncType::TEXTURE;
-							data.ResourceName		= dstPair.second;
+							data.ResourceName		= dstGUID.GetResourceName();
 							data.SrcLayout			= srcItr->TextureLayout;
 							data.DstLayout			= dstItr->TextureLayout;
 							data.SrcAccessFlag		= srcItr->AccessMask;
@@ -420,7 +415,7 @@ namespace Poly
 							syncPass->AddSyncData(data);
 
 							// m_pResourceCache->RegisterResource(syncPass->GetName() + "." + dstPair.second, 0, {}, srcName);
-							m_pResourceCache->RegisterSyncResource(syncPass->GetName() + "." + dstPair.second, srcName);
+							m_pResourceCache->RegisterSyncResource({ syncPass->GetName(), dstGUID.GetResourceName()}, srcGUID);
 							brokenEdges.insert(edgeID);
 
 							static_cast<RenderPass*>(passData.pPass.get())->SetAttachmentInital(dstItr->Name, srcItr->TextureLayout);
@@ -436,11 +431,11 @@ namespace Poly
 						if (BitsSet(dstItr->AccessMask, FAccessFlag::SHADER_WRITE) || BitsSet(srcItr->AccessMask, FAccessFlag::SHADER_WRITE)) // WAR or RAW
 						{
 							if (!syncPass)
-								syncPass = SyncPass::Create("Presync for " + dstPair.first);
+								syncPass = SyncPass::Create("Presync for " + dstGUID.GetPassName());
 
 							SyncPass::SyncData data = {};
 							data.Type				= SyncPass::SyncType::BUFFER;
-							data.ResourceName		= dstPair.second;
+							data.ResourceName		= dstGUID.GetResourceName();
 							data.SrcLayout			= srcItr->TextureLayout; // These are undefined for this resource (buffer)
 							data.DstLayout			= dstItr->TextureLayout;
 							data.SrcAccessFlag		= srcItr->AccessMask;
@@ -450,7 +445,7 @@ namespace Poly
 							syncPass->AddSyncData(data);
 
 							// m_pResourceCache->RegisterResource(syncPass->GetName() + "." + dstPair.second, 0, {}, srcName);
-							m_pResourceCache->RegisterSyncResource(syncPass->GetName() + "." + dstPair.second, srcName);
+							m_pResourceCache->RegisterSyncResource({ syncPass->GetName(), dstGUID.GetResourceName()}, srcGUID);
 							brokenEdges.insert(edgeID);
 						}
 						else // Read after read
@@ -594,14 +589,14 @@ namespace Poly
 
 			for (const uint32 brokenEdgeID : syncPassData.brokenEdgeIDs)
 			{
-				RenderGraph::EdgeData edge = m_pRenderGraph->GetEdgeData(brokenEdgeID);
+				const ResourceGUID dstGUID = m_pRenderGraph->GetEdgeData(brokenEdgeID).Dst;
+				const ResourceGUID srcGUID = m_pRenderGraph->GetEdgeData(brokenEdgeID).Src;
 				// Current implementation assumes that the resource name is set to dst resource name
-				PassResourcePair dstPair = m_pRenderGraph->GetPassNameResourcePair(edge.Dst);
 
 				// Add links for new pass
-				m_pRenderGraph->RemoveLink(edge.Src, edge.Dst);
-				m_pRenderGraph->AddLink(edge.Src, syncPassData.pSyncPass->GetName() + "." + dstPair.second);
-				m_pRenderGraph->AddLink(syncPassData.pSyncPass->GetName() + "." + dstPair.second, edge.Dst);
+				m_pRenderGraph->RemoveLink(srcGUID, dstGUID);
+				m_pRenderGraph->AddLink(srcGUID, { syncPassData.pSyncPass->GetName(), dstGUID.GetResourceName()});
+				m_pRenderGraph->AddLink({ syncPassData.pSyncPass->GetName(), dstGUID.GetResourceName()}, dstGUID);
 			}
 		}
 	}

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraphCompiler.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraphCompiler.h
@@ -9,6 +9,7 @@ namespace Poly
 	class Resource;
 	class RenderPass;
 	class RenderGraph;
+	class ResourceGUID;
 	class ResourceCache;
 	class RenderGraphProgram;
 
@@ -38,8 +39,8 @@ namespace Poly
 		void ValidateGraph();
 		void AllocateResources();
 		void AddSync(bool* pNewPasses);
-		bool IsResourceUsed(uint32 nodeIndex, const std::string& outputName);
-		bool IsResourceGraphOutput(uint32 nodeIndex, const std::string& outputName);
+		bool IsResourceUsed(const ResourceGUID& resourceGUID, uint32 nodeIndex);
+		bool IsResourceGraphOutput(const ResourceGUID& resourceGUID, uint32 nodeIndex);
 		FAccessFlag GetAccessFlag(FResourceBindPoint bindPoint, bool isInput);
 		FPipelineStage GetPipelineStage(FResourceBindPoint bindPoint);
 

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraphProgram.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraphProgram.cpp
@@ -174,43 +174,41 @@ namespace Poly
 		m_pStagingBufferCache->Update(m_ImageIndex);
 	}
 
-	void RenderGraphProgram::UpdateGraphResource(const std::string& name, const Resource* pResource, uint32 index)
+	void RenderGraphProgram::UpdateGraphResource(ResourceGUID resourceGUID, const Resource* pResource, uint32 index)
 	{
 		if (!pResource)
 		{
-			UpdateGraphResource(name, ResourceView::Empty(), 0, index);
+			UpdateGraphResource(resourceGUID, ResourceView::Empty(), 0, index);
 		}
 		else if (pResource->IsBuffer())
 		{
 			const Buffer* pBuffer = pResource->GetAsBuffer();
-			UpdateGraphResource(name, {pBuffer, pBuffer->GetSize(), 0}, 0, index);
+			UpdateGraphResource(resourceGUID, {pBuffer, pBuffer->GetSize(), 0}, 0, index);
 		}
 		else if (pResource->IsTexture())
 		{
 			const TextureView* pTextureView = pResource->GetAsTextureView();
 			const Sampler* pSampler = pResource->GetAsSampler();
-			UpdateGraphResource(name, {pTextureView, pSampler}, 0, index);
+			UpdateGraphResource(resourceGUID, {pTextureView, pSampler}, 0, index);
 		}
 	}
 
-	void RenderGraphProgram::UpdateGraphResource(const std::string& name, ResourceView view, uint64 offset, uint32 index)
+	void RenderGraphProgram::UpdateGraphResource(ResourceGUID resourceGUID, ResourceView view, uint64 offset, uint32 index)
 	{
-		PassResourcePair passPair = GetPassResourcePair(name);
-
 		// Go through each pass and find where resource is being used
 		for (uint32 passIndex = 0; passIndex < m_Passes.size(); passIndex++)
 		{
 			auto& pPass = m_Passes[passIndex];
 
-			if (pPass->GetPassType() == Pass::Type::SYNC || (pPass->GetName() != passPair.first && view.IsEmpty()))
+			if (pPass->GetPassType() == Pass::Type::SYNC || (pPass->GetName() != resourceGUID.GetPassName() && view.IsEmpty()))
 			{
 				continue;
 			}
 
 
 			// Check if pass has the requested resource, continue if not
-			const ResourceGUID mappedResource = GetMappedResourceGUID({ passPair.first, passPair.second }, pPass, passIndex);
-			if (!mappedResource.IsValid())
+			const ResourceGUID mappedResource = GetMappedResourceGUID(resourceGUID, pPass, passIndex);
+			if (!mappedResource.HasResource())
 				continue;
 
 			// Resource is being used in pass, update corresponding descriptor
@@ -254,15 +252,13 @@ namespace Poly
 		}
 	}
 
-	void RenderGraphProgram::UpdateGraphResource(const std::string& name, uint64 size, const void* data, uint64 offset, uint32 index)
+	void RenderGraphProgram::UpdateGraphResource(ResourceGUID resourceGUID, uint64 size, const void* data, uint64 offset, uint32 index)
 	{
-		PassResourcePair passPair = GetPassResourcePair(name);
-		std::string resourceName = passPair.first.empty() ? ("$." + passPair.second) : name;
-		const Resource* pRes = m_pResourceCache->GetResource(resourceName);
+		const Resource* pRes = m_pResourceCache->GetResource(resourceGUID);
 
 		if (!pRes)
 		{
-			POLY_CORE_ERROR("UpdateGraphResource - cannot update resource {} as it was not in the resource cache", name);
+			POLY_CORE_ERROR("UpdateGraphResource - cannot update resource {} as it was not in the resource cache", resourceGUID.GetResourceName());
 			return;
 		}
 
@@ -276,18 +272,18 @@ namespace Poly
 		bool hasSizeChanged = oldSize != size;
 		if (oldSize < size)
 		{
-			pRes = m_pResourceCache->UpdateResourceSize(resourceName, size);
+			pRes = m_pResourceCache->UpdateResourceSize(resourceGUID, size);
 		}
 
 		m_pStagingBufferCache->QueueTransfer(pRes->GetAsBuffer(), size, offset, data);
 
 		if (hasSizeChanged)
 		{
-			UpdateGraphResource(name, pRes, index);
+			UpdateGraphResource(resourceGUID, pRes, index);
 		}
 		else
 		{
-			UpdateGraphResource(name, nullptr, index);
+			UpdateGraphResource(resourceGUID, nullptr, index);
 		}
 	}
 
@@ -576,7 +572,7 @@ namespace Poly
 	ResourceGUID RenderGraphProgram::GetMappedResourceGUID(const ResourceGUID& resourceGUID, const Ref<Pass>& pPass, uint32 passIndex)
 	{
 		ResourceGUID mappedResource = m_pResourceCache->GetMappedResourceName(resourceGUID, pPass->GetName());
-		if (!mappedResource.IsValid())
+		if (!mappedResource.HasResource())
 			return ResourceGUID::Invalid();
 
 		const auto& reflections = m_Reflections[passIndex].GetIOData(FIOType::INPUT, FResourceBindPoint::ALL_SCENES);

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraphProgram.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraphProgram.h
@@ -59,7 +59,7 @@ namespace Poly
 		 * @param pResource - resource to update with - nullptr if resource is same and only updated binding. If resource is provided, all bindings using this resource will also be updated.
 		 * @param index - index of descriptor to update if multiple resources per binding point
 		 */
-		void UpdateGraphResource(const std::string& name, const Resource* pResource, uint32 index = 0);
+		void UpdateGraphResource(ResourceGUID resourceGUID, const Resource* pResource, uint32 index = 0);
 
 		/**
 		 * Updates a resource's descriptor - must be done when the resource has changed size or if
@@ -69,7 +69,7 @@ namespace Poly
 		 * @param offset - offset of the descriptor to update - remember to check the offset of the ResourceView as well
 		 * @param index - index of descriptor to update if multiple resources per binding point
 		 */
-		void UpdateGraphResource(const std::string& name, ResourceView view, uint64 offset = 0, uint32 index = 0);
+		void UpdateGraphResource(ResourceGUID resourceGUID, ResourceView view, uint64 offset = 0, uint32 index = 0);
 
 		/**
 		 * Updates a resource's descriptor - must be done when the resource has changed size or if
@@ -80,7 +80,7 @@ namespace Poly
 		 * @param offset - offset of the descriptor to update - remember to check the offset of the data as well
 		 * @param index - index of descriptor to update if multiple resources per binding point
 		 */
-		void UpdateGraphResource(const std::string& name, uint64 size, const void* data, uint64 offset = 0, uint32 index = 0);
+		void UpdateGraphResource(ResourceGUID resourceGUID, uint64 size, const void* data, uint64 offset = 0, uint32 index = 0);
 
 		/**
 		 * USED BY THE RENDERER

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraphTypes.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraphTypes.h
@@ -7,23 +7,6 @@ namespace Poly
 	class Sampler;
 	class Resource;
 
-	using PassResourcePair = std::pair<std::string, std::string>;
-
-	inline std::pair<std::string, std::string> SeparateStrings(const std::string& value, char separator)
-	{
-		auto pos = value.find_first_of(separator);
-
-		if (pos == std::string::npos)
-			return { "", value };
-
-		return { value.substr(0, pos), value.substr(pos + 1) };
-	}
-
-	inline PassResourcePair GetPassResourcePair(const std::string& name)
-	{
-		return SeparateStrings(name, '.');
-	}
-
 	inline FTextureUsage ConvertResourceBindPointToTextureUsage(FResourceBindPoint bindPoint)
 	{
 		FTextureUsage mask = FTextureUsage::NONE;

--- a/Poly/src/Poly/Rendering/RenderGraph/ResourceCache.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/ResourceCache.h
@@ -13,11 +13,11 @@ namespace Poly
 	private:
 		struct ResourceData
 		{
-			std::pair<uint32, uint32>	Lifetime	= {0, 0};
-			Ref<Resource>				pResource	= nullptr;
-			std::string					Name		= "";
-			IOData						IOInfo		= {};
-			bool						IsOutput	= false;
+			std::pair<uint32, uint32>	Lifetime		= {0, 0};
+			Ref<Resource>				pResource		= nullptr;
+			ResourceGUID				ResourceGUID	= ResourceGUID::Invalid();
+			IOData						IOInfo			= {};
+			bool						IsOutput		= false;
 		};
 
 	public:
@@ -33,7 +33,7 @@ namespace Poly
 		 * @param name - name of resource following $.resourceName format
 		 * @param resourceInfo - resource info (pResource & autobind)
 		 */
-		void RegisterExternalResource(const std::string& name, ResourceInfo resourceInfo);
+		void RegisterExternalResource(const ResourceGUID& resourceGUID, ResourceInfo resourceInfo);
 
 		/**
 		 * Registers a resource to be created
@@ -42,9 +42,9 @@ namespace Poly
 		 * @param iodata - IOData for the resource
 		 * @param alias - [optional] informs that the resource is going by another name added previously
 		 */
-		void RegisterResource(const std::string& name, uint32 timepoint, IOData iodata, const std::string& alias = "");
+		void RegisterResource(const ResourceGUID& resourceGUID, uint32 timepoint, IOData iodata, const ResourceGUID& aliasGUID = ResourceGUID::Invalid());
 
-		void RegisterSyncResource(const std::string& name, const std::string& alias);
+		void RegisterSyncResource(const ResourceGUID& resourceGUID, const ResourceGUID& aliasGUID);
 
 		/**
 		 * Mark a resource as being the output of the graph - this will
@@ -52,7 +52,7 @@ namespace Poly
 		 * @param name - name of resource following renderPass.resourceName format
 		 * @param iodata - IOData for that resource
 		 */
-		void MarkOutput(const std::string& name, IOData iodata);
+		void MarkOutput(const ResourceGUID& resourceGUID, IOData iodata);
 
 		/**
 		 * Sets the current backbuffer resource for this frame to be used
@@ -71,7 +71,7 @@ namespace Poly
 		 * 
 		 * @return pointer to resource
 		 */
-		Resource* GetResource(const std::string& name);
+		Resource* GetResource(const ResourceGUID& resourceGUID);
 
 		/**
 		* Gets the mapped resource name, i.e. resource "pass.resource" retruns the mapped name for "passName.resource"
@@ -86,7 +86,7 @@ namespace Poly
 		* Update a resource size
 		* WARNING: Old data will be deleted when size is changed. 
 		*/
-		Resource* UpdateResourceSize(const std::string& name, uint64 size);
+		Resource* UpdateResourceSize(const ResourceGUID& resourceGUID, uint64 size);
 
 		/**
 		 * Resets the cache, losing ownership of resource and clears vectors
@@ -98,9 +98,9 @@ namespace Poly
 
 		RenderGraphDefaultParams m_DefaultParams;
 
-		std::unordered_map<std::string, uint32> m_NameToIndex;
+		std::unordered_map<ResourceGUID, uint32, ResourceGUIDHasher> m_NameToIndex;
 		std::vector<ResourceData> m_Resources;
-		std::unordered_map<std::string, uint32> m_NameToExternalIndex;
+		std::unordered_map<ResourceGUID, uint32, ResourceGUIDHasher> m_NameToExternalIndex;
 		std::vector<ResourceInfo> m_ExternalResources;
 	};
 }

--- a/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.cpp
@@ -15,13 +15,37 @@ namespace
 
 namespace Poly
 {
-	ResourceGUID::ResourceGUID(std::string resourceGUID)
+	ResourceGUID::ResourceGUID(const std::string& resourceGUID)
 		: m_Pass(SeparateStrings(resourceGUID, '.').first)
 		, m_Resource(SeparateStrings(resourceGUID, '.').second) {}
 
 	ResourceGUID::ResourceGUID(std::string pass, std::string resource)
-		: m_Pass(pass.empty() ? "$" : pass)
-		, m_Resource(resource) {}
+		: m_Pass(pass.empty() ? "$" : std::move(pass))
+		, m_Resource(std::move(resource)) {}
+
+	ResourceGUID::ResourceGUID(const ResourceGUID& other)
+		: m_Pass(other.m_Pass)
+		, m_Resource(other.m_Resource) {}
+
+	ResourceGUID::ResourceGUID(ResourceGUID&& other)
+		: m_Pass(std::move(other.m_Pass))
+		, m_Resource(std::move(other.m_Resource)) {}
+
+	ResourceGUID& ResourceGUID::operator=(const ResourceGUID& other)
+	{
+		m_Pass		= other.m_Pass;
+		m_Resource	= other.m_Resource;
+		return *this;
+	}
+
+	ResourceGUID& ResourceGUID::operator=(ResourceGUID&& other)
+	{
+		m_Pass		= std::move(other.m_Pass);
+		m_Resource	= std::move(other.m_Resource);
+		return *this;
+	}
+
+	ResourceGUID::~ResourceGUID() = default;
 
 	ResourceGUID ResourceGUID::Invalid()
 	{
@@ -48,7 +72,7 @@ namespace Poly
 		return m_Pass == "$";
 	}
 
-	bool ResourceGUID::IsValid() const
+	bool ResourceGUID::HasResource() const
 	{
 		return !m_Resource.empty();
 	}
@@ -61,5 +85,10 @@ namespace Poly
 			return m_Resource == other.m_Resource;
 		else
 			return m_Pass == other.m_Pass && m_Resource == other.m_Resource;
+	}
+
+	ResourceGUID::operator std::string() const
+	{
+		return GetFullName();
 	}
 }

--- a/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.cpp
@@ -15,6 +15,10 @@ namespace
 
 namespace Poly
 {
+	ResourceGUID::ResourceGUID()
+		: m_Pass("")
+		, m_Resource("") {}
+
 	ResourceGUID::ResourceGUID(const std::string& resourceGUID)
 		: m_Pass(SeparateStrings(resourceGUID, '.').first)
 		, m_Resource(SeparateStrings(resourceGUID, '.').second) {}

--- a/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.h
@@ -5,6 +5,7 @@ namespace Poly
 	class ResourceGUID
 	{
 	public:
+		ResourceGUID();
 		ResourceGUID(const std::string& resourceGUID);
 		ResourceGUID(std::string pass, std::string resource);
 

--- a/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.h
+++ b/Poly/src/Poly/Rendering/RenderGraph/ResourceGUID.h
@@ -5,8 +5,15 @@ namespace Poly
 	class ResourceGUID
 	{
 	public:
-		ResourceGUID(std::string resourceGUID);
+		ResourceGUID(const std::string& resourceGUID);
 		ResourceGUID(std::string pass, std::string resource);
+
+		ResourceGUID(const ResourceGUID& other);
+		ResourceGUID(ResourceGUID&& other);
+		ResourceGUID& operator=(const ResourceGUID& other);
+		ResourceGUID& operator=(ResourceGUID&& other);
+		~ResourceGUID();
+
 
 		static ResourceGUID Invalid();
 
@@ -15,12 +22,21 @@ namespace Poly
 		std::string GetFullName() const;
 		
 		bool IsExternal() const;
-		bool IsValid() const;
+		bool HasResource() const;
 
 		bool operator==(const ResourceGUID& other) const;
+		operator std::string() const;
 	
 	private:
-		const std::string m_Pass;
-		const std::string m_Resource;
+		std::string m_Pass;
+		std::string m_Resource;
+	};
+
+	struct ResourceGUIDHasher
+	{
+		size_t operator()(const ResourceGUID& key) const
+		{
+			return std::hash<std::string>()(key.GetFullName());
+		}
 	};
 }

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -56,25 +56,25 @@ public:
 		Poly::Ref<Poly::Scene> pScene = Poly::Scene::Create();
 
 		// External resources
-		m_pGraph->AddExternalResource("camera", sizeof(CameraBuffer), Poly::FBufferUsage::UNIFORM_BUFFER);
-		m_pGraph->AddExternalResource("lights", sizeof(LightBuffer), Poly::FBufferUsage::STORAGE_BUFFER);
+		m_pGraph->AddExternalResource({ "camera" }, sizeof(CameraBuffer), Poly::FBufferUsage::UNIFORM_BUFFER);
+		m_pGraph->AddExternalResource({ "lights" }, sizeof(LightBuffer), Poly::FBufferUsage::STORAGE_BUFFER);
 		m_pGraph->AddExternalResource(pScene->GetResourceGroup());
 
 		// Passes and links
 		m_pGraph->AddPass(pPass, "pbrPass");
-		m_pGraph->AddLink("$.camera", "pbrPass.camera");
-		m_pGraph->AddLink("$.lights", "pbrPass.lights");
+		m_pGraph->AddLink({ "$.camera" }, { "pbrPass.camera" });
+		m_pGraph->AddLink({ "$.lights" }, { "pbrPass.lights" });
 		// m_pGraph->AddLink("$.scene:instance", "pbrPass.scene:instance"); // Do this for each resource
 
 		m_pGraph->AddPass(pImGuiPass, "ImGuiPass");
-		m_pGraph->AddLink("pbrPass.out", "ImGuiPass.out");
-		m_pGraph->MarkOutput("ImGuiPass.out");
+		m_pGraph->AddLink({ "pbrPass.out" }, { "ImGuiPass.out" });
+		m_pGraph->MarkOutput({ "ImGuiPass.out" });
 
 		// Compile
 		m_pProgram = m_pGraph->Compile();
 
 		LightBuffer data = {};
-		m_pProgram->UpdateGraphResource("lights", sizeof(LightBuffer), &data);
+		m_pProgram->UpdateGraphResource({ "lights" }, sizeof(LightBuffer), &data);
 
 		m_pProgram->SetScene(pScene);
 
@@ -106,7 +106,7 @@ public:
 
 		pCamera->Update(dt);
 		CameraBuffer data = {pCamera->GetMatrix(), pCamera->GetPosition()};
-		m_pProgram->UpdateGraphResource("camera", sizeof(CameraBuffer), &data);
+		m_pProgram->UpdateGraphResource({ "camera" }, sizeof(CameraBuffer), &data);
 		m_pRenderer->Render();
 	};
 


### PR DESCRIPTION
- Refactored all "renderPass.resourceName" logic to use ResourceGUID instead
- Removed all "." occurrences that were related to this logic