### PR TITLE
refactor: descriptor cache now uses sync points to remove desc.

### DIFF
--- a/Poly/src/Platform/API/SyncPoint.h
+++ b/Poly/src/Platform/API/SyncPoint.h
@@ -41,8 +41,7 @@ namespace Poly
 		virtual uint64 GetValue() const = 0;
 
 		/**
-		* Add where the sync point should wait, given that it is submitted as a wait sync point.
-		* Value is ignored if submitted as a signal sync point
+		* Add where the sync point should wait or signal, depending what it is submitted as.
 		* @param stage - the pipeline stage to wait for. Pipeline stage needs to be available on the current queue for proper use
 		*/
 		virtual void AddWaitStageMask(FPipelineStage stage) = 0;

--- a/Poly/src/Poly/Rendering/RenderGraph/RenderGraphProgram.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/RenderGraphProgram.cpp
@@ -84,9 +84,14 @@ namespace Poly
 		renderData.SetScene(m_pScene.get());
 		for (const auto& [pPass, reflection, _, passIndex] : m_Passes)
 		{
+			std::vector<SyncPointValue> signalSyncPoints;
+
 			// Clear old descriptors
-			if (m_DescriptorCaches.contains(passIndex))
-				m_DescriptorCaches[passIndex].Update();
+			if (auto itr = m_DescriptorCaches.find(passIndex); itr != m_DescriptorCaches.end())
+			{
+				itr->second.Update();
+				signalSyncPoints.push_back(itr->second.GetSignalSyncPointValue());
+			}
 
 			// Set inital pass values
 			CommandBuffer* currentCommandBuffer = GetCommandBuffer(passIndex);
@@ -173,6 +178,7 @@ namespace Poly
 			// Only graphics queue at the moment
 			SubmitDesc submitDesc = {};
 			submitDesc.CommandBuffers = { currentCommandBuffer };
+			submitDesc.SignalSyncPoints = signalSyncPoints;
 			RenderAPI::GetCommandQueue(FQueueType::GRAPHICS)->Submit(submitDesc);
 		}
 

--- a/Poly/src/Poly/Rendering/Utilities/DescriptorCache.cpp
+++ b/Poly/src/Poly/Rendering/Utilities/DescriptorCache.cpp
@@ -5,14 +5,22 @@
 
 namespace Poly
 {
+	DescriptorCache::DescriptorCache()
+	{
+		m_pSyncPoint = RenderAPI::CreateSyncPoint();
+	}
+
+	SyncPointValue DescriptorCache::GetSignalSyncPointValue()
+	{
+		return { m_pSyncPoint.get(), m_SyncPointValue };
+	}
+
 	void DescriptorCache::Update()
 	{
-		// TODO: this should not rely on a "DeadTimer", as it does not scale with multiple windows.
-		// Use timeline semaphores to properly check "death" of a descriptor
-		for (auto& removableDescriptor : m_RemovableDescriptors)
-			removableDescriptor.DeadTimer++;
+		m_SyncPointValue++;
+		const uint64 currentSignaledValue = m_pSyncPoint->GetValue();
 
-		auto it = std::remove_if(m_RemovableDescriptors.begin(), m_RemovableDescriptors.end(), [](const RemovableDescriptorSet& info) { return info.DeadTimer > 6; });
+		auto it = std::remove_if(m_RemovableDescriptors.begin(), m_RemovableDescriptors.end(), [currentSignaledValue](const RemovableDescriptorSet& info) { return info.SyncPointValue < currentSignaledValue; });
 		m_RemovableDescriptors.erase(it, m_RemovableDescriptors.end());
 	}
 
@@ -29,8 +37,7 @@ namespace Poly
 		Ref<DescriptorSet> pNewDescriptor = RenderAPI::CreateDescriptorSetCopy(pOldDescriptor);
 		m_Descriptors[set][index][offset] = pNewDescriptor;
 
-		// m_DescriptorsToBeDeleted[frameIndex].push_back(pOldDescriptor);
-		m_RemovableDescriptors.push_back(RemovableDescriptorSet(pOldDescriptor));
+		m_RemovableDescriptors.push_back(RemovableDescriptorSet(pOldDescriptor, m_SyncPointValue));
 
 		return pNewDescriptor.get();
 	}

--- a/Poly/src/Poly/Rendering/Utilities/DescriptorCache.h
+++ b/Poly/src/Poly/Rendering/Utilities/DescriptorCache.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Platform/API/SyncPoint.h"
+
 namespace Poly
 {
 	class DescriptorSet;
@@ -10,20 +12,26 @@ namespace Poly
 	private:
 		struct RemovableDescriptorSet
 		{
-			RemovableDescriptorSet(Ref<DescriptorSet> pSet) : pSet(pSet) {}
+			RemovableDescriptorSet(Ref<DescriptorSet> pSet, uint64 currentSyncPointValue) : pSet(pSet), SyncPointValue(currentSyncPointValue) {}
 
 			Ref<DescriptorSet> pSet = nullptr;
-			uint8 DeadTimer			= 0;
+			uint64 SyncPointValue	= 0;
 		};
 
 	public:
-		DescriptorCache() = default;
+		DescriptorCache();
 		~DescriptorCache() = default;
 
 		enum class EAction {
 			GET,
 			GET_OR_CREATE
 		};
+
+		/**
+		* Used to clear up the cache correctely. Call this ONCE per frame submit to make sure the cache gets notified when a frame is done.
+		* @return SyncPoint
+		*/
+		SyncPointValue GetSignalSyncPointValue();
 
 		/**
 		 * Needs to be called every frame to delete any old descriptor sets.
@@ -86,7 +94,8 @@ namespace Poly
 
 		PipelineLayout* m_pPipelineLayout = nullptr;
 		std::unordered_map<uint32, std::vector<std::vector<Ref<DescriptorSet>>>> m_Descriptors;
-		// std::unordered_map<uint32, std::vector<Ref<DescriptorSet>>> m_DescriptorsToBeDeleted;
 		std::vector<RemovableDescriptorSet> m_RemovableDescriptors;
+		Ref<SyncPoint> m_pSyncPoint;
+		uint64 m_SyncPointValue = 0;
 	};
 }


### PR DESCRIPTION
Issue #86 

- Changed so that descriptor cache is using a proper syncpoint to remove caches, instead of relying on a non-correct incrementing value on the CPU side only, which breaks with multi-windows.