### PR TITLE
feat: introduce formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,103 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+ContinuationIndentWidth: 4
+
+# Braces - Allman style (opening brace always on new line)
+# SplitEmptyFunction: false collapses empty bodies to {} on the same line:
+#   Foo()
+#       : m_Bar(bar)
+#       , m_Baz(baz) {}
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:        true
+  AfterClass:            true
+  AfterControlStatement: Always
+  AfterEnum:             true
+  AfterFunction:         true
+  AfterNamespace:        true
+  AfterStruct:           true
+  AfterUnion:            true
+  AfterExternBlock:      true
+  BeforeCatch:           true
+  BeforeElse:            true
+  BeforeLambdaBody:      false
+  BeforeWhile:           false
+  IndentBraces:          false
+  SplitEmptyFunction:    false
+  SplitEmptyRecord:      false
+  SplitEmptyNamespace:   false
+
+# Access modifiers sit at the same indent level as class members
+AccessModifierOffset: 0
+
+# Indent namespace body
+NamespaceIndentation: All
+
+# Pointer/reference qualifier attached to type (int* a, int& b)
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+# No enforced column limit
+ColumnLimit: 0
+
+# Short inline functions allowed on one line (e.g. getters/static factories)
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Inline
+
+# Constructor initializer lists - one initializer per line, comma-first style:
+#   Constructor()
+#       : m_Foo(foo)
+#       , m_Bar(bar) {}
+BreakConstructorInitializers: BeforeComma
+PackConstructorInitializers: Never
+ConstructorInitializerIndentWidth: 4
+
+# Spacing
+SpaceBeforeParens: ControlStatements
+SpaceAfterCStyleCast: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpacesInAngles: Never
+SpaceAfterTemplateKeyword: false
+
+# Align consecutive variable declarations/assignments with tabs
+AlignConsecutiveAssignments:
+  Enabled:          true
+  AcrossEmptyLines: false
+  AcrossComments:   false
+AlignConsecutiveDeclarations:
+  Enabled:          true
+  AcrossEmptyLines: false
+  AcrossComments:   false
+
+# Include sorting
+# Groups (separated by blank lines):
+#   1. Own header        - auto-detected by clang-format (same basename as source file)
+#   2. Project headers   - quoted includes: "Poly/...", "Platform/...", relative paths
+#   3. Third-party libs  - angle-bracket includes for libs in libs/ (imgui, glm, VMA, etc.)
+#   4. System headers    - angle-bracket includes for STL / OS / Vulkan SDK headers
+#
+# Note: polypch.h is force-included by the compiler and does not need to appear
+# explicitly in source files. Removing it avoids a conflict with "own header first".
+# All external lib includes should use angle brackets <> (not quotes).
+SortIncludes: CaseInsensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Third-party libraries (libs/ dependencies)  →  group 3
+  - Regex:    '^<(imgui|glm|vk_mem_alloc|vulkan|spdlog|assimp|SPIRV|glslang|entt|yaml-cpp|stb)'
+    Priority: 3
+  # System / STL headers  →  group 4
+  - Regex:    '^<'
+    Priority: 4
+  # Project headers (quoted)  →  group 2
+  # (own header is auto-detected at priority 0 and always placed first)
+  - Regex:    '^"'
+    Priority: 2

--- a/Poly/src/Platform/Vulkan/VmaInclude.cpp
+++ b/Poly/src/Platform/Vulkan/VmaInclude.cpp
@@ -2,4 +2,4 @@
 
 #define VMA_IMPLEMENTATION
 
-#include "vk_mem_alloc.h"
+#include <vk_mem_alloc.h>

--- a/Poly/src/Platform/Vulkan/VmaInclude.h
+++ b/Poly/src/Platform/Vulkan/VmaInclude.h
@@ -17,6 +17,6 @@
 #pragma warning(disable: 4189) // local variable is initialized but not referenced
 #pragma warning(disable: 4324) // structure was padded due to alignment specifier
 
-#include "vk_mem_alloc.h"
+#include <vk_mem_alloc.h>
 
 #pragma warning(pop)

--- a/Poly/src/Poly/Core/Logger.cpp
+++ b/Poly/src/Poly/Core/Logger.cpp
@@ -3,7 +3,7 @@
 
 #pragma warning(push)
 #pragma warning( disable : 26439 26451 26495 26439 26451 26495 26812 6385 26498 26450 26437 6285)
-#include "spdlog/sinks/stdout_color_sinks.h"
+#include <spdlog/sinks/stdout_color_sinks.h>
 #pragma warning(pop)
 
 

--- a/Poly/src/Poly/Core/Logger.h
+++ b/Poly/src/Poly/Core/Logger.h
@@ -1,10 +1,10 @@
 #pragma once
-#pragma 
+#pragma
 
 #pragma warning(push)
 #pragma warning( disable : 26439 26451 26495 26439 26451 26495 26812 6385 26498 26450 26437 6285)
 #define FMT_USE_USER_DEFINED_LITERALS 0
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 #pragma warning(pop)
 
 

--- a/Poly/src/Poly/Model/Mesh.h
+++ b/Poly/src/Poly/Model/Mesh.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "glm/glm.hpp"
+#include <glm/glm.hpp>
 #include "Platform/API/GraphicsPipeline.h"
 
 namespace Poly

--- a/Poly/src/Poly/Rendering/RenderGraph/PassResID.cpp
+++ b/Poly/src/Poly/Rendering/RenderGraph/PassResID.cpp
@@ -5,36 +5,40 @@
 namespace Poly
 {
 	PassResID::PassResID()
-		: m_Pass("")
-		, m_Resource("") {}
+	    : m_Pass("")
+	    , m_Resource("")
+	{}
 
 	PassResID::PassResID(const std::string& passName, const std::string& resourceName)
-		: m_Pass(passName.empty() ? "$" : passName)
-		, m_Resource(resourceName) {}
+	    : m_Pass(passName.empty() ? "$" : passName)
+	    , m_Resource(resourceName)
+	{}
 
 	PassResID::PassResID(const PassID& pass, const ResID& resource)
-		: m_Pass(pass)
-		, m_Resource(resource) {}
+	    : m_Pass(pass)
+	    , m_Resource(resource)
+	{}
 
 	PassResID::PassResID(const PassResID& other)
-		: m_Pass(other.m_Pass)
-		, m_Resource(other.m_Resource) {}
+	    : m_Pass(other.m_Pass)
+	    , m_Resource(other.m_Resource)
+	{}
 
 	PassResID::PassResID(PassResID&& other)
-		: m_Pass(std::move(other.m_Pass))
-		, m_Resource(std::move(other.m_Resource)) {}
-
+	    : m_Pass(std::move(other.m_Pass))
+	    , m_Resource(std::move(other.m_Resource))
+	{}
 
 	PassResID& PassResID::operator=(const PassResID& other)
 	{
-		m_Pass = other.m_Pass;
+		m_Pass     = other.m_Pass;
 		m_Resource = other.m_Resource;
 		return *this;
 	}
 
 	PassResID& PassResID::operator=(PassResID&& other)
 	{
-		m_Pass = std::move(other.m_Pass);
+		m_Pass     = std::move(other.m_Pass);
 		m_Resource = std::move(other.m_Resource);
 		return *this;
 	}
@@ -73,4 +77,4 @@ namespace Poly
 		else
 			return m_Pass == other.m_Pass && m_Resource == other.m_Resource;
 	}
-}
+} // namespace Poly

--- a/Poly/src/polypch.h
+++ b/Poly/src/polypch.h
@@ -15,10 +15,10 @@
 #pragma warning(push)
 #pragma warning(disable : 26495) // Disable uninitalized warning from GLM (it's a lot)
 #define GLM_ENABLE_EXPERIMENTAL
-#include "glm/glm.hpp"
-#include "glm/gtc/matrix_transform.hpp"
-#include "glm/gtx/quaternion.hpp"
-#include "glm/gtc/quaternion.hpp"
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtx/quaternion.hpp>
+#include <glm/gtc/quaternion.hpp>
 #pragma warning(pop)
 
 // Custom files


### PR DESCRIPTION
closes #60 

## Changes
- All external libs are now using `<>` instead of `""`
- Clang-format rules following the mostly set code standard introduced
- Added include order to clang-format